### PR TITLE
feat!: support suffix in input and remove icon prop

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,7 +6,17 @@ module.exports = {
     '../src/**/*.stories.@(js|jsx|ts|tsx)'
   ],
   'addons': [
-    '@storybook/preset-scss',
+    {
+      name: '@storybook/preset-scss',
+      options: {
+        cssLoaderOptions: {
+          modules: {
+            localIdentName: '[name]__[local]--[hash:base64:5]',
+          },
+
+        }
+      }
+    },
     '@storybook/addon-a11y',
     '@storybook/addon-docs'
   ],

--- a/src/components/content/Icon/Icon.module.scss
+++ b/src/components/content/Icon/Icon.module.scss
@@ -1,4 +1,5 @@
 @use '../../../styles/variables/color';
+@use '../../../styles/variables/font';
 
 .icon {
   display: inline-block;
@@ -9,8 +10,6 @@
   svg {
     display: block;
     height: 1em;
-    position: relative;
-    top: -10%;
     width: 1em;
   }
 
@@ -20,5 +19,11 @@
 
   &--accent {
     color: color.$yellow;
+  }
+
+  @each $key, $size in font.$sizes {
+    &--#{$key} {
+      font-size: $size;
+    }
   }
 }

--- a/src/components/content/Icon/Icon.tsx
+++ b/src/components/content/Icon/Icon.tsx
@@ -7,6 +7,7 @@ interface IconProps {
   icon: string;
   color?: string;
   title?: string;
+  size?: string;
 }
 
 // Has to be a PureComponent so we get the shallow prop comparison
@@ -15,6 +16,7 @@ function Icon({
   icon,
   color,
   title,
+  size,
 }: IconProps) {
   const [IconSVG, setIcon] = useState(null);
   useEffect(() => {
@@ -30,6 +32,7 @@ function Icon({
     <span
       className={classNames(styles.icon, {
         [styles[`icon--${color}`]]: color,
+        [styles[`icon--${size}`]]: size,
       })}
       title={title}
       aria-hidden={!title}

--- a/src/components/controls/Input/Input.module.scss
+++ b/src/components/controls/Input/Input.module.scss
@@ -7,19 +7,21 @@
 .input {
   @include forms.input;
 
-  &__icon {
-    align-self: center;
-    font-size: font.$size-xl;
-    margin-right: -(math.div(input.$padding-horizontal, 2));
-    padding: 0 0 0 math.div(input.$padding-horizontal, 2);
-  }
-
-  &__prefix {
+  &__prefix,
+  &__suffix {
     align-self: center;
     font-weight: font.$weight-bold;
     line-height: font.$line-height;
+  }
+
+  &__prefix {
     margin-right: -(math.div(input.$padding-horizontal, 2));
     padding: 0 0 0 input.$padding-horizontal;
+  }
+
+  &__suffix {
+    margin-left: -(math.div(input.$padding-horizontal, 2));
+    padding: 0 input.$padding-horizontal 0 0;
   }
 
   &__input {

--- a/src/components/controls/Input/Input.stories.tsx
+++ b/src/components/controls/Input/Input.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Meta } from '@storybook/react/types-6-0';
 
+import Icon from '../../content/Icon/Icon';
 import Input from './Input';
 
 export default {
@@ -22,9 +23,17 @@ export default {
 } as Meta;
 
 export function Default() {
-  return <Input name="my-input" id="my-input" icon="search" />;
+  return <Input name="my-input" id="my-input" prefix={<Icon icon="search" size="lg" />} />;
 }
 
 export function Prefix() {
   return <Input name="my-input" id="my-input" prefix="£" />;
+}
+
+export function Suffix() {
+  return <Input name="my-input" id="my-input" suffix="kr" />;
+}
+
+export function SuffixAsIcon() {
+  return <Input name="my-input" id="my-input" suffix={<Icon icon="calendar" size="lg" />} />;
 }

--- a/src/components/controls/Input/Input.tsx
+++ b/src/components/controls/Input/Input.tsx
@@ -4,8 +4,6 @@ import classNames from 'classnames';
 import { BaseInputProps } from 'lib/types';
 import { defaultInputProps } from 'lib/default-props';
 
-import Icon from 'components/content/Icon/Icon';
-
 import styles from './Input.module.scss';
 
 interface InputProps extends BaseInputProps {
@@ -15,8 +13,8 @@ interface InputProps extends BaseInputProps {
 
 const Input = React.forwardRef((
   {
-    icon,
     prefix,
+    suffix,
     disabled,
     touched,
     valid,
@@ -33,17 +31,17 @@ const Input = React.forwardRef((
       [styles[`input--${status}`]]: status,
     })}
   >
-    {icon && (
-      <div className={styles.input__icon}>
-        <Icon icon={icon} />
-      </div>
-    )}
-    {!icon && prefix && (
+    {prefix && (
       <div className={styles.input__prefix}>
         {prefix}
       </div>
     )}
     <input className={styles.input__input} disabled={disabled} {...props} ref={ref} />
+    {suffix && (
+      <div className={styles.input__suffix}>
+        {suffix}
+      </div>
+    )}
   </div>
 ));
 


### PR DESCRIPTION
Add suffix to `Input`, but remove the icon prop so we can generically support any prefix or suffix. 
Fixes #18 