### PR TITLE
fix: make output file same name as the type file

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,8 +109,8 @@
     "react-hook-form": "7.38.0",
     "react-textarea-autosize": "^8.3.3"
   },
-  "main": "dist/mobius.cjs.js",
-  "module": "dist/mobius.esm.js",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
   "src": "src/index.tsx",
   "files": [
     "dist",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -31,11 +31,11 @@ const inputOptions = {
 
 const outputOptions = [
   {
-    file: 'dist/mobius.cjs.js',
+    file: 'dist/index.cjs.js',
     format: 'cjs',
   },
   {
-    file: 'dist/mobius.esm.js',
+    file: 'dist/index.esm.js',
     format: 'esm',
   },
 ];


### PR DESCRIPTION
Make the output file the same name as the type definition file so typescript picks it up, fixes #13 