### PR TITLE
fix: use rems for breakpoints

### DIFF
--- a/src/styles/variables/breakpoint.scss
+++ b/src/styles/variables/breakpoint.scss
@@ -1,13 +1,13 @@
 $xs: 0;
-$sm: 30em; // 480
-$md: 37.5em; // 600
-$lg: 48em; // 768
-$xl: 64em; // 1024
-$xxl: 80em; // 1280
-$xxxl: 90em; // 1440
+$sm: 30rem; // 480
+$md: 37.5rem; // 600
+$lg: 48rem; // 768
+$xl: 64rem; // 1024
+$xxl: 80rem; // 1280
+$xxxl: 90rem; // 1440
 $tablet: $lg;
 $desktop: $xl;
-$max: 90em; // 1440
+$max: 90rem; // 1440
 
 $map: (
   xs: $xs,


### PR DESCRIPTION
Use rems for breakpoints so they don't get affected by context