### PR TITLE
Input types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "mono-icons": "1.3.1",
         "normalize.css": "8.0.1",
         "react-a11y-dialog": "^6.2.0",
-        "react-hook-form": "7.38.0",
         "react-textarea-autosize": "^8.3.3"
       },
       "devDependencies": {
@@ -26809,21 +26808,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-hook-form": {
-      "version": "7.38.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.38.0.tgz",
-      "integrity": "sha512-gxWW1kMeru9xR1GoR+Iw4hA+JBOM3SHfr4DWCUKY0xc7Vv1MLsF109oHtBeWl9shcyPFx67KHru44DheN0XY5A==",
-      "engines": {
-        "node": ">=12.22.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/react-hook-form"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17 || ^18"
-      }
-    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -52861,11 +52845,6 @@
           "dev": true
         }
       }
-    },
-    "react-hook-form": {
-      "version": "7.38.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.38.0.tgz",
-      "integrity": "sha512-gxWW1kMeru9xR1GoR+Iw4hA+JBOM3SHfr4DWCUKY0xc7Vv1MLsF109oHtBeWl9shcyPFx67KHru44DheN0XY5A=="
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "mono-icons": "1.3.1",
     "normalize.css": "8.0.1",
     "react-a11y-dialog": "^6.2.0",
-    "react-hook-form": "7.38.0",
     "react-textarea-autosize": "^8.3.3"
   },
   "main": "dist/index.cjs.js",

--- a/src/components/controls/Checkbox/Checkbox.tsx
+++ b/src/components/controls/Checkbox/Checkbox.tsx
@@ -1,15 +1,15 @@
 import React, { useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 
-import { BaseInputProps } from 'lib/types';
 import { defaultInputProps } from 'lib/default-props';
 import useCombinedRefs from 'lib/hooks/combined-refs';
 
 import Icon from 'components/content/Icon/Icon';
+import { FormControl } from '../../../types/form-control.type';
 
 import styles from './Checkbox.module.scss';
 
-interface CheckboxProps extends BaseInputProps {
+interface CheckboxProps extends FormControl {
   defaultChecked?: boolean;
   forceChecked?: boolean;
   type?: 'default' | 'list' | 'input';

--- a/src/components/controls/Input/Input.tsx
+++ b/src/components/controls/Input/Input.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { BaseInputProps } from 'lib/types';
 import { defaultInputProps } from 'lib/default-props';
+import { FormControl } from '../../../types/form-control.type';
 
 import styles from './Input.module.scss';
 
-interface InputProps extends BaseInputProps {
+interface InputProps extends FormControl {
   icon?: string;
   prefix?: string;
+  suffix?: string;
+  [key: string]: any;
 }
 
 const Input = React.forwardRef((

--- a/src/components/controls/Radio/Radio.tsx
+++ b/src/components/controls/Radio/Radio.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { BaseInputProps } from 'lib/types';
 import { defaultInputProps } from 'lib/default-props';
-
-import { ChangeHandler } from 'react-hook-form';
+import { FormControl } from '../../../types/form-control.type';
 import styles from './Radio.module.scss';
 
-interface RadioProps extends BaseInputProps {
+interface RadioProps extends FormControl {
   checked?: boolean;
   children: React.ReactNode;
   /**
@@ -16,7 +14,7 @@ interface RadioProps extends BaseInputProps {
    * the onChange event for the last radio in the DOM with the registered name
    * instead of the onChange for this radio!
    */
-  onRadioChange: ChangeHandler;
+  onRadioChange?: Function;
 }
 
 const Radio = React.forwardRef((

--- a/src/components/controls/Select/Select.tsx
+++ b/src/components/controls/Select/Select.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { BaseInputProps } from 'lib/types';
 import { defaultInputProps } from 'lib/default-props';
-
 import Icon from 'components/content/Icon/Icon';
+import { FormControl } from '../../../types/form-control.type';
 
 import styles from './Select.module.scss';
 
-interface SelectProps extends BaseInputProps {
+interface SelectProps extends FormControl {
   children: React.ReactNode;
 }
 

--- a/src/components/controls/Textarea/Textarea.tsx
+++ b/src/components/controls/Textarea/Textarea.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import TextareaAutosize from 'react-textarea-autosize';
 import classNames from 'classnames';
 
-import { BaseInputProps } from 'lib/types';
 import { defaultInputProps } from 'lib/default-props';
+import { FormControl } from '../../../types/form-control.type';
 
 import styles from './Textarea.module.scss';
 
@@ -14,7 +14,7 @@ const Textarea = React.forwardRef((
     valid,
     status,
     ...props
-  }: BaseInputProps,
+  }: FormControl,
   ref: any,
 ) => (
   <div

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,7 +1,0 @@
-import { UseFormRegisterReturn } from 'react-hook-form';
-
-export interface BaseInputProps extends UseFormRegisterReturn {
-  touched?: boolean;
-  valid?: boolean;
-  [x: string]: any;
-}

--- a/src/types/form-control.type.ts
+++ b/src/types/form-control.type.ts
@@ -1,0 +1,9 @@
+import { ModerationStatus } from './moderation-status.type';
+
+export interface FormControl {
+  touched?: boolean;
+  valid?: boolean;
+  status?: ModerationStatus;
+  disabled?: boolean;
+  [key: string]: any;
+}

--- a/src/types/moderation-status.type.ts
+++ b/src/types/moderation-status.type.ts
@@ -1,0 +1,9 @@
+export type ModerationStatus =
+  'PENDING' |
+  'LIVE' |
+  'REJECTED' |
+  'HISTORICAL' |
+  'HISTORICAL_PENDING' |
+  'REMOVAL_PENDING' |
+  'REMOVAL_REJECTED' |
+  'REMOVAL_APPROVED';


### PR DESCRIPTION
Errors occurred on applying basic props to inputs.

I think this probably comes about because of the hidden react-hook-form dependency.

This is a quick patch to remove the dependency, might review the types some more later.
