### PR TITLE
Grid full width should be optional

### DIFF
--- a/src/components/composition/Grid/Grid.tsx
+++ b/src/components/composition/Grid/Grid.tsx
@@ -45,17 +45,6 @@ const Grid = ({
   return <div className={cx}>{children}</div>;
 };
 
-Grid.defaultProps = {
-  wrap: undefined,
-  inset: undefined,
-  insetFluid: undefined,
-  insetVerticalFluid: undefined,
-  direction: undefined,
-  justify: undefined,
-  align: undefined,
-  spacing: undefined,
-};
-
 Grid.Item = Item;
 
 export default Grid;

--- a/src/components/composition/Grid/GridItem.tsx
+++ b/src/components/composition/Grid/GridItem.tsx
@@ -76,22 +76,4 @@ const Item = ({
   return <div className={cx}>{children}</div>;
 };
 
-Item.defaultProps = {
-  children: null,
-  grow: undefined,
-  shrink: undefined,
-  align: undefined,
-  xs: undefined,
-  sm: undefined,
-  md: undefined,
-  lg: undefined,
-  xl: undefined,
-  xxl: undefined,
-  xxxl: undefined,
-  max: undefined,
-  desktop: undefined,
-  flex: undefined,
-  order: undefined,
-};
-
 export default Item;


### PR DESCRIPTION
Making the new grid `fullWidth` prop non-optional has [caused me a mischief](https://github.com/etchteam/eteep/actions/runs/3632276541/jobs/6127940212).

Also the default props, this is probably just a hangover from LAP but:

- Same as what react would assign anyway
- Different to the default args
- We don't need default props ever anymore