### PR TITLE
Nicer modal api

### DIFF
--- a/src/components/composition/Modal/Modal.stories.tsx
+++ b/src/components/composition/Modal/Modal.stories.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { Meta } from '@storybook/react/types-6-0';
-import A11yDialogInstance from 'a11y-dialog';
 
 import Card from 'components/canvas/Card/Card';
 import Button from 'components/controls/Button/Button';
 import Icon from 'components/content/Icon/Icon';
 
-import Modal from './Modal';
+import Modal, { useModalRef } from './Modal';
 import Grid from '../Grid/Grid';
 
 export default {
@@ -18,7 +17,7 @@ export default {
 } as Meta;
 
 export const Default = () => {
-  const modalRef = React.useRef<A11yDialogInstance>();
+  const modalRef = useModalRef();
 
   return (
     <>
@@ -30,9 +29,8 @@ export const Default = () => {
         id="story-modal"
         title="Modal title"
         size="lg"
-        setupRef={(instance) => {
-          modalRef.current = instance;
-        }}
+        ref={modalRef}
+        onModalMounted={(modalInstance) => modalInstance.current?.show()}
       >
         <Card border>
           <Card.Body>

--- a/src/components/composition/Modal/Modal.tsx
+++ b/src/components/composition/Modal/Modal.tsx
@@ -8,18 +8,37 @@ import { Breakpoints } from '../../../types/breakpoints.type';
 import styles from './Modal.module.scss';
 import Inner from './Inner';
 
+export type ModalInstance = A11yDialogInstance;
+
 interface ModalProps extends Pick<A11yDialogProps, 'id' | 'title' | 'role'> {
   children: React.ReactNode;
   size?: Breakpoints | 'auto';
-  setupRef?: (instance: A11yDialogInstance) => void;
+  /**
+   * Called when the modal has mounted and the ref has been setup
+   */
+  onModalMounted?: (modalRef: React.MutableRefObject<ModalInstance>) => void;
 }
 
-const Modal = ({
-  children, size = 'auto', setupRef, ...a11yDialogProps
-}: ModalProps) => {
+const Modal = React.forwardRef<any, ModalProps>((
+  {
+    children, size = 'auto', onModalMounted, ...a11yDialogProps
+  },
+  ref: React.ForwardedRef<ModalInstance>,
+) => {
   const dialogClasses = classnames(styles.modal__dialog, {
     [styles[`modal__dialog--size-${size}`]]: size,
   });
+
+  const setupRef = (instance: ModalInstance) => {
+    if (typeof ref !== 'function' && ref) {
+      // eslint-disable-next-line no-param-reassign
+      ref.current = instance;
+
+      if (typeof onModalMounted === 'function') {
+        onModalMounted(ref as React.MutableRefObject<ModalInstance>);
+      }
+    }
+  };
 
   return (
     <A11yDialog
@@ -36,8 +55,9 @@ const Modal = ({
       {children}
     </A11yDialog>
   );
-};
+});
 
-Modal.Inner = Inner;
+export const useModalRef = () => React.useRef<ModalInstance>();
 
-export default Modal;
+// eslint-disable-next-line prefer-object-spread
+export default Object.assign({}, Modal, { Inner });


### PR DESCRIPTION
BREAKING CHANGES

- Pass ref as a prop instead of using `setupRef`
- Use `useModalRef` instead of `React.useRef<A11YDialogInstance>`
- Exports `ModalInstance` for types
- Adds a `onModalMounted` function to tell when the ref is ready

Fixes https://github.com/etchteam/mobius/issues/63

