### PR TITLE
feat!: extract component css to own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Install the global CSS in your main app file;
 
 ```js
 import '@etchteam/mobius/src/styles/main.scss';
+import '@etchteam/mobius/components.css';
 ```
 
 Import a theme file

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -26,6 +26,8 @@ const inputOptions = {
     }),
     postcss({
       modules: true,
+      extract: 'components.css',
+      minimize: true,
     }),
     // Get the custom icons
     copy({


### PR DESCRIPTION
Fixes the FOUC when using the components in Next.js/SSR by moving the component CSS to an extracted CSS file