### PR TITLE
Stop card headers having their own styles

### DIFF
--- a/src/components/canvas/Card/Card.module.scss
+++ b/src/components/canvas/Card/Card.module.scss
@@ -33,13 +33,10 @@
       border-bottom: 0;
     }
 
-    // Come back to bite me?
     h1,
     h2,
     h3,
     h4 {
-      font-size: font.$size-xl;
-      font-weight: font.$weight-base;
       margin: 0;
     }
   }


### PR DESCRIPTION
Removes the specific style mods for `h` elements placed within `Card.Header` because it conflicts with heading styles and sizes in individual projects and we have other text/title helper components to size things appropriately