### PR TITLE
fix: 75096typeof is not a valid attribute on svg

### DIFF
--- a/src/components/content/Icon/Icon.stories.tsx
+++ b/src/components/content/Icon/Icon.stories.tsx
@@ -22,7 +22,7 @@ const customIconNames = importAll(require.context('./custom-icons/', true, /\.sv
 const Template = ({ iconNames, type }: { iconNames: string[], type?: 'mono' | 'custom' }) => (
   <Grid wrap>
     {iconNames.map((icon) => (
-      <Grid.Item xs={6} sm={3} md={2} flex>
+      <Grid.Item xs={6} sm={3} md={2} flex key={icon}>
         <Card border>
           <Card.Body>
             <TextAlign align="center">

--- a/src/components/content/Icon/Icon.tsx
+++ b/src/components/content/Icon/Icon.tsx
@@ -21,6 +21,20 @@ interface IconProps {
   baseline?: boolean;
 }
 
+const defaultIcon = {
+  default() {
+    return (
+      <svg
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      />
+    );
+  },
+};
+
 // Has to be a PureComponent so we get the shallow prop comparison
 // and runs shouldComponentUpdate otherwise the icon flashes when state changes
 function Icon({
@@ -31,17 +45,19 @@ function Icon({
   type = 'mono',
   baseline = true,
 }: IconProps) {
-  const [IconSVG, setIcon] = useState(null);
+  const [iconImport, setIcon] = useState(defaultIcon);
   useEffect(() => {
     const fetchIcon = async () => {
       const dynamicIcon = type === 'custom'
         ? await import(`!!@svgr/webpack?{ svgo: false }!./custom-icons/${icon}.svg`)
         : await import(`!!@svgr/webpack?{ svgo: false }!mono-icons/svg/${icon}.svg`);
-      setIcon(dynamicIcon.default);
+      setIcon(dynamicIcon);
     };
 
     fetchIcon();
   }, [icon, type]);
+
+  const IconSVG = iconImport ? iconImport.default : null;
 
   return (
     <span
@@ -53,7 +69,7 @@ function Icon({
       title={title}
       aria-hidden={!title}
     >
-      {IconSVG}
+      {IconSVG && (<IconSVG />)}
     </span>
   );
 }


### PR DESCRIPTION
Fix the error with icons by tweaking the import so we use the component in a more normal way.

```
next-dev.js?3515:20 Warning: Invalid value for prop `$$typeof` on <svg> tag. Either remove it from the element, or pass a string or number value to keep it in the DOM. For details, see https://reactjs.org/link/attribute-behavior 
```