### PR TITLE
Fix: enter component width

### DIFF
--- a/src/components/composition/Enter/Enter.module.scss
+++ b/src/components/composition/Enter/Enter.module.scss
@@ -53,7 +53,6 @@ $enter-transition-timing: ease-in-out;
   animation-fill-mode: forwards;
   animation-iteration-count: 1;
   animation-timing-function: $enter-transition-timing;
-  min-width: 100%;
   position: relative;
   z-index: 1;
 
@@ -92,5 +91,9 @@ $enter-transition-timing: ease-in-out;
 
   &--flex {
     display: flex;
+  }
+
+  &--full-width {
+    min-width: 100%;
   }
 }

--- a/src/components/composition/Enter/Enter.tsx
+++ b/src/components/composition/Enter/Enter.tsx
@@ -9,17 +9,20 @@ export default function Enter({
   delay,
   enter,
   flex,
+  fullWidth,
 }: {
   children?: React.ReactNode;
   type?: string;
   delay?: string;
   enter?: boolean;
   flex?: boolean;
+  fullWidth?: boolean;
 }) {
   const cx = classNames(styles.enter, {
     [styles[`enter--${type}`]]: type,
     [styles['enter--enter']]: enter,
     [styles['enter--flex']]: flex,
+    [styles['enter--full-width']]: fullWidth,
   });
   return (
     <div className={cx} style={{ animationDelay: delay }}>


### PR DESCRIPTION
The `min-width: 100%` causes elements in Safari to break out of their grid container and break the page layout.

Made this optional so we still have the power if we need it.