### PR TITLE
Label alignment

### DIFF
--- a/src/components/composition/FormGroup/FormGroup.module.scss
+++ b/src/components/composition/FormGroup/FormGroup.module.scss
@@ -5,7 +5,9 @@
 
 .form-group {
   &__label {
+    column-gap: spacing.$horizontal-sm;
     display: grid;
+    grid-auto-rows: min-content;
     grid-template-columns: 1fr auto;
   }
 

--- a/src/components/composition/FormGroup/FormGroup.stories.tsx
+++ b/src/components/composition/FormGroup/FormGroup.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta } from '@storybook/react/types-6-0';
 import React, { useState } from 'react';
 
+import Grid from '../Grid/Grid';
 import Skin from '../Skin/Skin';
 import Spacing from '../Spacing/Spacing';
 
@@ -10,6 +11,7 @@ import Alert from 'components/canvas/Alert/Alert';
 import Icon from 'components/content/Icon/Icon';
 import Input from 'components/controls/Input/Input';
 import Label from 'components/controls/Label/Label';
+import Radio from 'components/controls/Radio/Radio';
 import TextButton from 'components/controls/TextButton/TextButton';
 
 export default {
@@ -30,14 +32,39 @@ Default.storyName = 'Form group';
 
 export function Horizontal() {
   return (
-    <FormGroup horizontal>
-      <FormGroup.Label>
-        <Label htmlFor="my-input">Input label</Label>
-      </FormGroup.Label>
-      <FormGroup.Control>
-        <Input id="my-input" name="my-input" />
-      </FormGroup.Control>
-    </FormGroup>
+    <>
+      <FormGroup horizontal>
+        <FormGroup.Label>
+          <Label htmlFor="my-input">Input label</Label>
+        </FormGroup.Label>
+        <FormGroup.Control>
+          <Input id="my-input" name="my-input" />
+        </FormGroup.Control>
+      </FormGroup>
+
+      <Spacing bottom="lg" />
+
+      <FormGroup horizontal>
+        <FormGroup.Label>
+          <Label id="my-input-two">
+            Input label with a bigger list of form controls
+          </Label>
+        </FormGroup.Label>
+        <FormGroup.Control>
+          <div role="radiogroup" aria-labelledby="my-input-two">
+            <Grid wrap>
+              {[1, 2, 3, 4].map((option) => (
+                <Grid.Item xs={12} key={option}>
+                  <Radio value={option} name="my-radio-input">
+                    Option {option}
+                  </Radio>
+                </Grid.Item>
+              ))}
+            </Grid>
+          </div>
+        </FormGroup.Control>
+      </FormGroup>
+    </>
   );
 }
 


### PR DESCRIPTION
**Min content rows**

Fixes labels inside `FormControl.Label` aligning center.

Before
![Screenshot 2023-03-29 at 14 15 23](https://user-images.githubusercontent.com/5038459/228552065-7c70b00a-aaba-40e2-be54-e5360f9e89bc.png)

After
![Screenshot 2023-03-29 at 14 15 51](https://user-images.githubusercontent.com/5038459/228552105-68b4bcad-11fc-4f31-a955-2c4dc5198ea7.png)

**Column gap**

Fixes info btns going annoyingly close to labels

Before
![Screenshot 2023-03-29 at 14 19 16](https://user-images.githubusercontent.com/5038459/228552140-a5b2b60c-8d9c-47d5-ac38-12d7e765c337.png)

After (closest it can get)
![Screenshot 2023-03-29 at 14 24 57](https://user-images.githubusercontent.com/5038459/228552477-c6a590cd-199e-48af-bb5e-d3353839a932.png)


