### PR TITLE
Collapse extras

### DIFF
--- a/src/components/controls/Collapse/Collapse.stories.tsx
+++ b/src/components/controls/Collapse/Collapse.stories.tsx
@@ -22,7 +22,7 @@ Default.args = {
   align: 'left',
   iconOpen: 'chevron-up',
   iconClosed: 'chevron-down',
-  initiallyOpen: false,
+  defaultOpen: false,
 };
 
 export const RightAlign: Story = () => (
@@ -33,10 +33,10 @@ export const RightAlign: Story = () => (
   </Collapse>
 );
 
-export const InitiallyOpen: Story = () => (
-  <Collapse headerLabel="Click me" initiallyOpen>
+export const DefaultOpen: Story = () => (
+  <Collapse headerLabel="Click me" defaultOpen>
     <div>
-      <p>Collapse open from initial render</p>
+      <p>Collapse is open from initial render</p>
     </div>
   </Collapse>
 );

--- a/src/components/controls/Collapse/Collapse.tsx
+++ b/src/components/controls/Collapse/Collapse.tsx
@@ -15,7 +15,7 @@ export interface CollapseProps {
   iconOpen?: string;
   iconClosed?: string;
   onToggle?: (open?: boolean) => void;
-  initiallyOpen?: boolean;
+  defaultOpen?: boolean;
 }
 
 const Collapse = ({
@@ -25,9 +25,9 @@ const Collapse = ({
   iconOpen = 'chevron-up',
   iconClosed = 'chevron-down',
   onToggle,
-  initiallyOpen = false,
+  defaultOpen = false,
 }: CollapseProps) => {
-  const [open, setOpen] = useState(initiallyOpen);
+  const [open, setOpen] = useState(defaultOpen);
 
   const toggle = () => {
     setOpen(!open);


### PR DESCRIPTION
Additional optional props for Collapse component
- `initiallyOpen` - to set the collapse `open` state from initial render
- `iconOpen` and `iconClosed` - to change the default icons for the open and closed states