### PR TITLE
Slider props spread type

### DIFF
--- a/src/components/controls/Slider/Slider.tsx
+++ b/src/components/controls/Slider/Slider.tsx
@@ -15,6 +15,7 @@ export interface SliderProps extends FormControl {
   defaultValue?: number;
   min?: number;
   max?: number;
+  [key: string]: unknown;
 }
 
 const Slider = React.forwardRef(


### PR DESCRIPTION
This component spreads props onto the input, but no extra props are accepted in the components type definition. Which causes an error:

![Screenshot 2023-04-18 at 13 33 03](https://user-images.githubusercontent.com/5038459/232778312-e3aa85a7-3fce-469b-b541-0b62e4b33413.png)

So the type has been updated to accept any extra props of unknown type.

Bonus points for anyone that can get to the bottom of why we never received a typescript error in this project: https://github.com/etchteam/mobius/issues/121