### PR TITLE
fix: control props

### DIFF
--- a/src/components/composition/Modal/Modal.tsx
+++ b/src/components/composition/Modal/Modal.tsx
@@ -62,5 +62,4 @@ Modal.displayName = 'Modal';
 
 export const useModalRef = () => React.useRef<ModalInstance>();
 
-// eslint-disable-next-line prefer-object-spread
 export default Object.assign({}, Modal, { Inner, Header });

--- a/src/components/content/Badge/Badge.tsx
+++ b/src/components/content/Badge/Badge.tsx
@@ -1,9 +1,9 @@
 import classNames from 'classnames';
 import React from 'react';
 
-import styles from './Badge.module.scss';
+import { Sizes } from '../../../types/font.type';
 
-import { Sizes } from 'src/types/font.type';
+import styles from './Badge.module.scss';
 
 export interface BadgeProps {
   children?: React.ReactNode;

--- a/src/components/content/BarStack/Item.tsx
+++ b/src/components/content/BarStack/Item.tsx
@@ -1,9 +1,9 @@
 import classnames from 'classnames';
 import React from 'react';
 
-import styles from './BarStack.module.scss';
+import { Colors } from '../../../types/colors.type';
 
-import { Colors } from 'src/types/colors.type';
+import styles from './BarStack.module.scss';
 
 export interface ItemProps {
   color: Colors;

--- a/src/components/content/StreamDot/StreamDot.tsx
+++ b/src/components/content/StreamDot/StreamDot.tsx
@@ -1,9 +1,9 @@
 import classnames from 'classnames';
 import React from 'react';
 
-import styles from './StreamDot.module.scss';
+import { StreamType } from '../../../types/stream.type';
 
-import { StreamType } from 'src/types/stream.type';
+import styles from './StreamDot.module.scss';
 
 interface StreamDotProps {
   stream?: StreamType;

--- a/src/components/controls/Button/Button.tsx
+++ b/src/components/controls/Button/Button.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, { forwardRef } from 'react';
+import React from 'react';
 
 import styles from './Button.module.scss';
 
@@ -15,20 +15,10 @@ interface ButtonProps {
   [x: string]: unknown;
 }
 
-const Button = forwardRef(
+const Button = React.forwardRef<any, ButtonProps>(
   (
-    {
-      children,
-      loading,
-      submit,
-      type,
-      href,
-      icon,
-      block,
-      size,
-      ...props
-    }: ButtonProps,
-    ref: any
+    { children, loading, submit, type, href, icon, block, size, ...props },
+    ref
   ) => {
     const baseProps = {
       className: classNames(styles.button, {
@@ -60,14 +50,8 @@ const Button = forwardRef(
   }
 );
 
-Button.defaultProps = {
-  submit: false,
-  loading: false,
-  type: undefined,
-  href: undefined,
-  icon: false,
-  block: undefined,
-};
 Button.displayName = 'Button';
 
-export default Button;
+export default Button as React.ForwardRefExoticComponent<
+  ButtonProps & React.RefAttributes<HTMLInputElement>
+>;

--- a/src/components/controls/Checkbox/Checkbox.tsx
+++ b/src/components/controls/Checkbox/Checkbox.tsx
@@ -6,7 +6,6 @@ import { FormControl } from '../../../types/form-control.type';
 import styles from './Checkbox.module.scss';
 
 import Icon from 'components/content/Icon/Icon';
-import { defaultInputProps } from 'lib/default-props';
 import useCombinedRefs from 'lib/hooks/combined-refs';
 
 interface CheckboxProps extends FormControl {
@@ -14,14 +13,15 @@ interface CheckboxProps extends FormControl {
   forceChecked?: boolean;
   type?: 'default' | 'list' | 'input';
   children?: React.ReactNode;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-const Checkbox = React.forwardRef(
+const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
   (
     {
       defaultChecked = false,
       forceChecked,
-      type,
+      type = 'input',
       children,
       disabled,
       touched,
@@ -76,13 +76,6 @@ const Checkbox = React.forwardRef(
     );
   }
 );
-
-Checkbox.defaultProps = {
-  ...defaultInputProps,
-  type: 'input',
-  defaultChecked: false,
-  forceChecked: undefined,
-};
 
 Checkbox.displayName = 'Checkbox';
 

--- a/src/components/controls/Datepicker/Datepicker.tsx
+++ b/src/components/controls/Datepicker/Datepicker.tsx
@@ -33,10 +33,9 @@ interface DatepickerProps extends FormControl {
   toMonth?: Date;
   fromYear?: number;
   toYear?: number;
-  [key: string]: any;
 }
 
-const Datepicker = React.forwardRef(
+const Datepicker = React.forwardRef<HTMLInputElement, DatepickerProps>(
   (
     {
       disabled,
@@ -51,8 +50,8 @@ const Datepicker = React.forwardRef(
       fromMonth,
       toMonth,
       ...props
-    }: DatepickerProps,
-    ref: any
+    },
+    ref
   ) => {
     const [selected, setSelected] = useState<Date>();
     const [isPopperOpen, setIsPopperOpen] = useState<boolean>(false);
@@ -188,4 +187,6 @@ const Datepicker = React.forwardRef(
 
 Datepicker.displayName = 'Datepicker';
 
-export default Datepicker;
+export default Datepicker as React.ForwardRefExoticComponent<
+  DatepickerProps & React.RefAttributes<HTMLInputElement>
+>;

--- a/src/components/controls/Input/Input.tsx
+++ b/src/components/controls/Input/Input.tsx
@@ -5,20 +5,13 @@ import { FormControl } from '../../../types/form-control.type';
 
 import styles from './Input.module.scss';
 
-import { defaultInputProps } from 'lib/default-props';
-
 interface InputProps extends FormControl {
-  icon?: string;
-  prefix?: string;
-  suffix?: string;
-  [key: string]: any;
+  prefix?: React.ReactNode | string;
+  suffix?: React.ReactNode | string;
 }
 
-const Input = React.forwardRef(
-  (
-    { prefix, suffix, disabled, touched, valid, status, ...props }: InputProps,
-    ref: any
-  ) => (
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ prefix, suffix, disabled, touched, valid, status, ...props }, ref) => (
     <div
       className={classNames(styles.input, {
         [styles['input--disabled']]: disabled,
@@ -39,11 +32,8 @@ const Input = React.forwardRef(
   )
 );
 
-Input.defaultProps = {
-  ...defaultInputProps,
-  icon: undefined,
-};
-
 Input.displayName = 'Input';
 
-export default Input;
+export default Input as React.ForwardRefExoticComponent<
+  InputProps & React.RefAttributes<HTMLInputElement>
+>;

--- a/src/components/controls/Radio/Radio.tsx
+++ b/src/components/controls/Radio/Radio.tsx
@@ -5,8 +5,6 @@ import { FormControl } from '../../../types/form-control.type';
 
 import styles from './Radio.module.scss';
 
-import { defaultInputProps } from 'lib/default-props';
-
 interface RadioProps extends FormControl {
   checked?: boolean;
   children?: React.ReactNode;
@@ -17,9 +15,10 @@ interface RadioProps extends FormControl {
    * instead of the onChange for this radio!
    */
   onRadioChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-const Radio = React.forwardRef(
+const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
   (
     {
       disabled,
@@ -31,8 +30,8 @@ const Radio = React.forwardRef(
       onRadioChange,
       onChange,
       ...props
-    }: RadioProps,
-    forwardedRef: any
+    },
+    forwardedRef
   ) => (
     <label
       className={classNames(styles.radio, {
@@ -49,12 +48,8 @@ const Radio = React.forwardRef(
         checked={checked}
         disabled={disabled}
         onChange={(event) => {
-          if (onRadioChange) {
-            onRadioChange(event);
-          }
-          if (onChange) {
-            onChange(event);
-          }
+          onRadioChange?.(event);
+          onChange?.(event);
         }}
         {...props}
         ref={forwardedRef}
@@ -67,11 +62,8 @@ const Radio = React.forwardRef(
   )
 );
 
-Radio.defaultProps = {
-  ...defaultInputProps,
-  checked: false,
-};
-
 Radio.displayName = 'Radio';
 
-export default Radio;
+export default Radio as React.ForwardRefExoticComponent<
+  RadioProps & React.RefAttributes<HTMLInputElement>
+>;

--- a/src/components/controls/Select/Select.tsx
+++ b/src/components/controls/Select/Select.tsx
@@ -6,17 +6,13 @@ import { FormControl } from '../../../types/form-control.type';
 import styles from './Select.module.scss';
 
 import Icon from 'components/content/Icon/Icon';
-import { defaultInputProps } from 'lib/default-props';
 
 interface SelectProps extends FormControl {
   children?: React.ReactNode;
 }
 
-const Select = React.forwardRef(
-  (
-    { children, disabled, touched, valid, status, ...props }: SelectProps,
-    ref: any
-  ) => (
+const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ children, disabled, touched, valid, status, ...props }, ref) => (
     <div
       className={classNames(styles.select, {
         [styles['select--disabled']]: disabled,
@@ -40,8 +36,8 @@ const Select = React.forwardRef(
   )
 );
 
-Select.defaultProps = defaultInputProps;
-
 Select.displayName = 'Select';
 
-export default Select;
+export default Select as React.ForwardRefExoticComponent<
+  SelectProps & React.RefAttributes<HTMLSelectElement>
+>;

--- a/src/components/controls/Slider/Slider.tsx
+++ b/src/components/controls/Slider/Slider.tsx
@@ -1,10 +1,10 @@
 import classNames from 'classnames';
 import React, { useState } from 'react';
 
+import { FormControl } from '../../../types/form-control.type';
+
 import styles from './Slider.module.scss';
 import Label from './SliderLabel';
-
-import { FormControl } from 'src/types/form-control.type';
 
 export interface SliderProps extends FormControl {
   children?: React.ReactNode;
@@ -13,32 +13,39 @@ export interface SliderProps extends FormControl {
     values: { lowerValue: number; upperValue: number }
   ) => void;
   defaultValue?: number;
-  min?: number;
-  max?: number;
-  [key: string]: unknown;
+  minValue?: number;
+  maxValue?: number;
 }
 
-const Slider = React.forwardRef(
+export interface SliderComponent
+  extends React.ForwardRefExoticComponent<
+    SliderProps & React.RefAttributes<HTMLInputElement>
+  > {
+  Label: typeof Label;
+}
+
+const Slider = React.forwardRef<HTMLInputElement, SliderProps>(
   (
     {
       children,
       onChange,
       defaultValue,
-      min = 0,
-      max = 100,
+      minValue = 0,
+      maxValue = 100,
       disabled,
       ...props
-    }: SliderProps,
-    ref: any
+    },
+    ref
   ) => {
     const defaultVal =
-      defaultValue ?? (max < min ? min : min + (max - min) / 2);
+      defaultValue ??
+      (maxValue < minValue ? minValue : minValue + (maxValue - minValue) / 2);
     const [value, setValue] = useState(defaultVal);
 
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
       const newValue = Number(e?.target?.value);
       setValue(newValue);
-      onChange?.(e, { lowerValue: newValue, upperValue: max - newValue });
+      onChange?.(e, { lowerValue: newValue, upperValue: maxValue - newValue });
     };
 
     // augment slider label children with value and max props
@@ -46,7 +53,7 @@ const Slider = React.forwardRef(
       if (React.isValidElement(child)) {
         return React.cloneElement(child as React.ReactElement<any>, {
           value,
-          max,
+          maxValue,
         });
       }
       return child;
@@ -60,8 +67,8 @@ const Slider = React.forwardRef(
         style={
           {
             '--slider-value': value,
-            '--slider-max': max,
-            '--slider-min': min,
+            '--slider-max': maxValue,
+            '--slider-min': minValue,
           } as React.CSSProperties
         }
       >
@@ -69,8 +76,8 @@ const Slider = React.forwardRef(
           <input
             type="range"
             defaultValue={defaultVal}
-            min={min}
-            max={max}
+            min={minValue}
+            max={maxValue}
             disabled={disabled}
             onChange={handleInputChange}
             {...props}
@@ -85,7 +92,4 @@ const Slider = React.forwardRef(
 
 Slider.displayName = 'Slider';
 
-const sliderComponent = Object.assign({}, Slider, { Label });
-sliderComponent.displayName = 'Slider';
-
-export default sliderComponent;
+export default Object.assign({}, Slider, { Label }) as SliderComponent;

--- a/src/components/controls/Slider/SliderLabel.tsx
+++ b/src/components/controls/Slider/SliderLabel.tsx
@@ -7,19 +7,19 @@ export interface SliderLabelProps {
   children?: React.ReactNode;
   position: 'upper' | 'lower';
   value?: number;
-  max?: number;
+  maxValue?: number;
   showValue?: boolean;
   asPercentage?: boolean;
 }
-const formatPercentage = (value: number, max: number) => {
-  return `${((value / max) * 100).toFixed(0)}%`;
+const formatPercentage = (value: number, maxValue: number) => {
+  return `${((value / maxValue) * 100).toFixed(0)}%`;
 };
 
 const SliderLabel = ({
   children,
   position,
   value,
-  max,
+  maxValue,
   showValue = false,
   asPercentage = false,
 }: SliderLabelProps) => {
@@ -27,7 +27,8 @@ const SliderLabel = ({
     return null;
   }
 
-  const displayValue = position === 'upper' && max ? max - value : value;
+  const displayValue =
+    position === 'upper' && maxValue ? maxValue - value : value;
 
   return (
     <div
@@ -37,8 +38,8 @@ const SliderLabel = ({
     >
       {children && <div>{children}</div>}
       {showValue &&
-        (asPercentage && max ? (
-          <div>{formatPercentage(displayValue, max)}</div>
+        (asPercentage && maxValue ? (
+          <div>{formatPercentage(displayValue, maxValue)}</div>
         ) : (
           <div>{displayValue}</div>
         ))}

--- a/src/components/controls/TextButton/TextButton.tsx
+++ b/src/components/controls/TextButton/TextButton.tsx
@@ -1,10 +1,11 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import { Weights } from '../../../types/font.type';
+
 import styles from './TextButton.module.scss';
 
 import Icon from 'components/content/Icon/Icon';
-import { Weights } from 'src/types/font.type';
 
 interface TextButtonProps {
   children?: React.ReactNode;

--- a/src/components/controls/Textarea/Textarea.tsx
+++ b/src/components/controls/Textarea/Textarea.tsx
@@ -6,10 +6,8 @@ import { FormControl } from '../../../types/form-control.type';
 
 import styles from './Textarea.module.scss';
 
-import { defaultInputProps } from 'lib/default-props';
-
-const Textarea = React.forwardRef(
-  ({ disabled, touched, valid, status, ...props }: FormControl, ref: any) => (
+const Textarea = React.forwardRef<HTMLTextAreaElement, FormControl>(
+  ({ disabled, touched, valid, status, ...props }, ref) => (
     <div
       className={classNames(styles.textarea, {
         [styles['input--disabled']]: disabled,
@@ -28,10 +26,8 @@ const Textarea = React.forwardRef(
   )
 );
 
-Textarea.defaultProps = {
-  ...defaultInputProps,
-};
-
 Textarea.displayName = 'Textarea';
 
-export default Textarea;
+export default Textarea as React.ForwardRefExoticComponent<
+  FormControl & React.RefAttributes<HTMLTextAreaElement>
+>;

--- a/src/lib/default-props.ts
+++ b/src/lib/default-props.ts
@@ -1,8 +1,0 @@
-/* eslint-disable import/prefer-default-export */
-
-export const defaultInputProps = {
-  disabled: false,
-  touched: undefined,
-  valid: undefined,
-  status: undefined,
-};

--- a/src/tokens/typography.stories.tsx
+++ b/src/tokens/typography.stories.tsx
@@ -4,10 +4,9 @@ import React from 'react';
 
 import Spacing from '../components/composition/Spacing/Spacing';
 import Text from '../components/content/Text/Text';
+import { Sizes } from '../types/font.type';
 
 import fonts from './typography.module.scss';
-
-import { Sizes } from 'src/types/font.type';
 
 export default {
   title: 'Tokens/Typography',

--- a/src/types/form-control.type.ts
+++ b/src/types/form-control.type.ts
@@ -5,5 +5,5 @@ export interface FormControl {
   valid?: boolean;
   status?: ModerationStatus;
   disabled?: boolean;
-  [key: string]: any;
+  [key: string]: unknown;
 }


### PR DESCRIPTION
Fixes:

- https://github.com/etchteam/mobius/issues/121 by overwriting the type that react provides to not use `Pick`
- Issue with control checkbox breaking the build
- Unecessary default props
- Bunch of incorrect paths (`src/` instead of `../`)

