### PR TITLE
Dropdown

### DIFF
--- a/src/components/controls/Dropdown/Content.tsx
+++ b/src/components/controls/Dropdown/Content.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import styles from './Dropdown.module.scss';
+
+// @TODO make this self aligning
+export default function DropdownContent({
+  children,
+}: {
+  children?: React.ReactNode;
+}) {
+  return <div className={styles.dropdown__content}>{children}</div>;
+}

--- a/src/components/controls/Dropdown/Dropdown.module.scss
+++ b/src/components/controls/Dropdown/Dropdown.module.scss
@@ -1,0 +1,32 @@
+@use '../../../styles/variables/color';
+@use '../../../styles/variables/spacing';
+@use '../../../styles/variables/transition';
+
+.dropdown {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+
+  &__content {
+    background: color.$white;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    left: auto;
+    min-width: 8em;
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    right: 0;
+    top: 100%;
+    transform: translateY(-0.25em);
+    transition: opacity transition.$duration transition.$timing,
+      transform transition.$duration transition.$timing;
+  }
+
+  &--open {
+    .dropdown__content {
+      opacity: 1;
+      pointer-events: auto;
+      transform: none;
+    }
+  }
+}

--- a/src/components/controls/Dropdown/Dropdown.stories.tsx
+++ b/src/components/controls/Dropdown/Dropdown.stories.tsx
@@ -1,0 +1,25 @@
+import { Meta } from '@storybook/react/types-6-0';
+import React, { useState } from 'react';
+
+import Dropdown from './Dropdown';
+
+import Button from 'components/controls/Button/Button';
+
+export default {
+  title: 'Controls/Dropdown',
+  component: Dropdown,
+} as Meta;
+
+export const Default = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <Dropdown open={open} onClickAway={() => setOpen(false)}>
+      <Button onClick={() => setOpen(!open)}>Dropdown</Button>
+      <Dropdown.Content>
+        <div>Content</div>
+      </Dropdown.Content>
+    </Dropdown>
+  );
+};
+
+Default.storyName = 'Dropdown';

--- a/src/components/controls/Dropdown/Dropdown.tsx
+++ b/src/components/controls/Dropdown/Dropdown.tsx
@@ -1,0 +1,43 @@
+import classNames from 'classnames';
+import React, { useEffect, useRef } from 'react';
+
+import Content from './Content';
+import styles from './Dropdown.module.scss';
+
+export interface DropdownProps {
+  open?: boolean;
+  onClickAway?: () => void;
+  children?: React.ReactNode;
+}
+
+const Dropdown = ({ open, onClickAway, children }: DropdownProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event) {
+      if (ref.current && !ref.current.contains(event.target)) {
+        onClickAway?.();
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [onClickAway]);
+
+  return (
+    <div
+      ref={ref}
+      className={classNames(styles.dropdown, {
+        [styles['dropdown--open']]: open,
+      })}
+    >
+      {children}
+    </div>
+  );
+};
+
+Dropdown.Content = Content;
+
+export default Dropdown;

--- a/src/components/controls/Fieldset/Fieldset.stories.tsx
+++ b/src/components/controls/Fieldset/Fieldset.stories.tsx
@@ -21,4 +21,4 @@ export function Default() {
   );
 }
 
-Default.storyName = 'Feidlset';
+Default.storyName = 'Fieldset';


### PR DESCRIPTION
Migrates the dropdown component from LA Portal.

Removes the react-click-away dependency.

Makes the Dropdown a "Control", seems more appropriate than "Canvas"?

We need this to have a place for the logout button to go on eTEEP (https://github.com/etchteam/eteep/issues/123)

https://github.com/etchteam/mobius/assets/5038459/171c1f62-557d-4545-975f-0508bc7a4e6a

