### PR TITLE
fix: checkbox width

### DIFF
--- a/src/components/composition/List/List.stories.tsx
+++ b/src/components/composition/List/List.stories.tsx
@@ -7,6 +7,7 @@ import Grid from 'components/composition/Grid/Grid';
 import Spacing from 'components/composition/Spacing/Spacing';
 import Icon from 'components/content/Icon/Icon';
 import Button from 'components/controls/Button/Button';
+import Checkbox from 'components/controls/Checkbox/Checkbox';
 
 export default {
   title: 'Composition/List',
@@ -65,4 +66,18 @@ export const Animated: ComponentStory<typeof List> = (args) => {
       </Grid>
     </>
   );
+};
+
+export const ListOfCheckboxes: ComponentStory<typeof List> = (args) => (
+  <List {...args}>
+    {[1, 2, 3, 4, 5].map((item) => (
+      <List.Item key={item}>
+        <Checkbox>{' * '.repeat(item)}</Checkbox>
+      </List.Item>
+    ))}
+  </List>
+);
+
+ListOfCheckboxes.args = {
+  spacing: 'sm',
 };

--- a/src/components/controls/Checkbox/Checkbox.module.scss
+++ b/src/components/controls/Checkbox/Checkbox.module.scss
@@ -8,6 +8,7 @@
 .checkbox {
   align-items: center;
   cursor: pointer;
+  width: 100%;
 
   + .checkbox {
     margin-top: spacing.$sm;


### PR DESCRIPTION
Adds `width: 100%` property to Checkbox component.

Does not change the component's appearance in normal situations. But it fixes a bug where Checkboxes used in ListItem components are the width of the content rather than full width. See new ListOfCheckboxes story for demonstration.

Needed for https://github.com/etchteam/eteep/issues/359