### PR TITLE
Add NextJS 13+ link support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,14 +8,14 @@
   "stylelint.validate": ["css", "scss"],
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
-    "source.fixAll.stylelint": true
+    "source.fixAll.eslint": "explicit",
+    "source.fixAll.stylelint": "explicit"
   },
   // Ensure the git config matches our commit convention
   "git.inputValidationSubjectLength": 100,
   "git.inputValidationLength": 100,
   "sonarlint.connectedMode.project": {
-    "connectionId": "etchteam",
+    "connectionId": "Etch",
     "projectKey": "etchteam_mobius"
   },
 }

--- a/src/components/controls/Button/Button.stories.tsx
+++ b/src/components/controls/Button/Button.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from '@storybook/react/types-6-0';
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 
 import Button from './Button';
 
@@ -62,5 +62,27 @@ export function Block() {
       <br />
       <Button block="mobile">Button Block Mobile</Button>
     </>
+  );
+}
+
+function LinkExample({
+  children,
+  ...props
+}: PropsWithChildren<{ [key: string]: unknown }>) {
+  return (
+    <a {...props} aria-label="Not just any link, a LinkExample link">
+      {children}
+    </a>
+  );
+}
+
+/**
+ * Use the `as` prop to control which component the Button renders as.
+ */
+export function AsComponent() {
+  return (
+    <Button as={LinkExample} href="#" block>
+      Link button
+    </Button>
   );
 }

--- a/src/components/controls/Button/Button.tsx
+++ b/src/components/controls/Button/Button.tsx
@@ -1,10 +1,15 @@
 import classNames from 'classnames';
-import React from 'react';
+import React, { ComponentType, ReactNode, forwardRef } from 'react';
 
 import styles from './Button.module.scss';
 
 interface ButtonProps {
-  children?: React.ReactNode;
+  children?: ReactNode;
+  /**
+   * The component to render the button as.
+   * Useful for routing in frameworks like NextJS: `<Button as={Link} href="/">`
+   */
+  as?: ComponentType<any>;
   submit?: boolean;
   loading?: boolean;
   href?: string;
@@ -15,11 +20,13 @@ interface ButtonProps {
   [x: string]: unknown;
 }
 
-const Button = React.forwardRef<any, ButtonProps>(
+const Button = forwardRef<any, ButtonProps>(
   (
-    { children, loading, submit, type, href, icon, block, size, ...props },
+    { children, as, loading, submit, type, href, icon, block, size, ...props },
     ref
   ) => {
+    const CustomTag = as ?? (href ? 'a' : 'button');
+
     const baseProps = {
       className: classNames(styles.button, {
         [styles[`button--${type}`]]: !!type,
@@ -29,23 +36,15 @@ const Button = React.forwardRef<any, ButtonProps>(
         [styles['button--icon']]: icon,
         [styles[`button--${size}`]]: !!size,
       }),
-      disabled: loading || undefined,
+      disabled: loading ?? undefined,
       ref,
       ...props,
     };
 
-    if (href) {
-      return (
-        <a {...baseProps} href={href}>
-          {children}
-        </a>
-      );
-    }
-
     return (
-      <button {...baseProps} type={submit ? 'submit' : 'button'}>
+      <CustomTag {...baseProps} href={href} type={submit ? 'submit' : 'button'}>
         {children}
-      </button>
+      </CustomTag>
     );
   }
 );


### PR DESCRIPTION
Allows `Button` to be rendered as a different component passed into `as` prop like: `<Button as={Link} href="/">` to work with NextJS links.

[Related writeup about why we need this](https://www.notion.so/etchteam/NextJS-links-with-functional-components-660f15db54c145b99efb0c8e79e2b3de?pvs=4)