### PR TITLE
Fix list a11y and list item width

### DIFF
--- a/src/components/composition/List/List.tsx
+++ b/src/components/composition/List/List.tsx
@@ -15,6 +15,7 @@ const List = ({
   const [parent] = useAutoAnimate();
   return (
     <ul
+      role="list"
       ref={parent}
       className={cx(styles.list, {
         [styles[`list--spacing-${spacing}`]]: spacing,

--- a/src/components/composition/List/ListItem.tsx
+++ b/src/components/composition/List/ListItem.tsx
@@ -11,7 +11,7 @@ export interface ListItemProps {
 const Item = ({ icon, children, ...props }: Readonly<ListItemProps>) => (
   <li className={styles.list__item} {...props}>
     {icon ? <div className={styles['list__item-icon']}>{icon}</div> : null}
-    {children}
+    <div className={styles['list__item-content']}>{children}</div>
   </li>
 );
 

--- a/src/styles/mixins/list.scss
+++ b/src/styles/mixins/list.scss
@@ -14,4 +14,8 @@
   &-icon {
     margin-right: spacing.$sm;
   }
+
+  &-content {
+    flex: 1 1 auto;
+  }
 }


### PR DESCRIPTION
The list mixin applies list style none, so `role="list"` is necessary because of [Safari accessibility concerns](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style#accessibility_concerns).

List items are display flex to support list item icons, but no width was applied to children which causes:
- block-level elements to unexpectedly not display at full width
- children to be displayed as a flex item so all on the same line with no wrapping
