### PR TITLE
feat: muted prop on card body

### DIFF
--- a/src/components/canvas/Card/Card.module.scss
+++ b/src/components/canvas/Card/Card.module.scss
@@ -93,7 +93,8 @@
     pointer-events: none;
   }
 
-  &--muted {
+  &--muted,
+  &__body--muted {
     background: skin.$background-muted;
   }
 }

--- a/src/components/canvas/Card/Card.stories.tsx
+++ b/src/components/canvas/Card/Card.stories.tsx
@@ -55,3 +55,22 @@ Arrow.args = {
     console.log('clicked');
   },
 };
+
+export const MutedBody = () => (
+  <Card>
+    <Card.Header>
+      <h2>Card title</h2>
+    </Card.Header>
+    <Card.Body muted>
+      Aliquam egestas mi quam, a tincidunt lectus faucibus euismod. Pellentesque
+      et metus nunc. Fusce ante arcu, mattis pretium semper ac, pretium vitae
+      velit. Donec vitae eros et arcu accumsan auctor at id ipsum. Aliquam
+      finibus, mi ac tincidunt blandit, purus elit ornare dui, nec dignissim mi
+      ante sit amet mauris. Nulla eget dui in mauris tempus tincidunt a eget
+      enim. Proin eu neque lorem. Sed quis tellus magna. Nunc scelerisque nisi
+      eget dictum laoreet. Nullam aliquam et massa id euismod. Interdum et
+      malesuada fames ac ante ipsum primis in faucibus. Nulla vehicula ornare
+      ligula nec rutrum. Maecenas convallis rutrum metus sed ultricies.
+    </Card.Body>
+  </Card>
+);

--- a/src/components/canvas/Card/CardBody.tsx
+++ b/src/components/canvas/Card/CardBody.tsx
@@ -8,6 +8,7 @@ interface CardBodyProps {
   padded?: boolean;
   border?: boolean;
   hidden?: boolean;
+  muted?: boolean;
 }
 
 export default function CardBody({
@@ -15,6 +16,7 @@ export default function CardBody({
   padded = true,
   border = false,
   hidden = false,
+  muted = false,
 }: Readonly<CardBodyProps>) {
   return (
     <div
@@ -22,6 +24,7 @@ export default function CardBody({
         [styles['card__body--padded']]: padded,
         [styles['card__body--border']]: border,
         [styles['card__body--hidden']]: hidden,
+        [styles['card__body--muted']]: muted,
       })}
     >
       {children}


### PR DESCRIPTION
Adds a `muted` prop to `Card.Body` so that it can be given a muted background independently of the rest of the card.
<img width="323" alt="Screenshot 2024-03-04 at 15 52 18" src="https://github.com/etchteam/mobius/assets/117105692/53b05c40-016f-4006-9896-3d3733b60c7b">
