### PR TITLE
fix: use display flex with card muted body

### DIFF
--- a/src/components/canvas/Card/Card.module.scss
+++ b/src/components/canvas/Card/Card.module.scss
@@ -97,4 +97,13 @@
   &__body--muted {
     background: skin.$background-muted;
   }
+
+  &:has(.card__body--muted) {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__body--muted {
+    flex: 1;
+  }
 }

--- a/src/components/canvas/Card/Card.stories.tsx
+++ b/src/components/canvas/Card/Card.stories.tsx
@@ -57,20 +57,34 @@ Arrow.args = {
 };
 
 export const MutedBody = () => (
-  <Card>
-    <Card.Header>
-      <h2>Card title</h2>
-    </Card.Header>
-    <Card.Body muted>
-      Aliquam egestas mi quam, a tincidunt lectus faucibus euismod. Pellentesque
-      et metus nunc. Fusce ante arcu, mattis pretium semper ac, pretium vitae
-      velit. Donec vitae eros et arcu accumsan auctor at id ipsum. Aliquam
-      finibus, mi ac tincidunt blandit, purus elit ornare dui, nec dignissim mi
-      ante sit amet mauris. Nulla eget dui in mauris tempus tincidunt a eget
-      enim. Proin eu neque lorem. Sed quis tellus magna. Nunc scelerisque nisi
-      eget dictum laoreet. Nullam aliquam et massa id euismod. Interdum et
-      malesuada fames ac ante ipsum primis in faucibus. Nulla vehicula ornare
-      ligula nec rutrum. Maecenas convallis rutrum metus sed ultricies.
-    </Card.Body>
-  </Card>
+  <Grid>
+    <Grid.Item xs={12} md={4} flex>
+      <Card border>
+        <Card.Header>
+          <h2>Card title</h2>
+        </Card.Header>
+        <Card.Body muted>
+          Aliquam egestas mi quam, a tincidunt lectus faucibus euismod.
+          Pellentesque et metus nunc. Fusce ante arcu, mattis pretium semper ac,
+          pretium vitae velit. Donec vitae eros et arcu accumsan auctor at id
+          ipsum. Aliquam finibus, mi ac tincidunt blandit, purus elit ornare
+          dui, nec dignissim mi ante sit amet mauris. Nulla eget dui in mauris
+          tempus tincidunt a eget enim. Proin eu neque lorem. Sed quis tellus
+          magna. Nunc scelerisque nisi eget dictum laoreet.
+        </Card.Body>
+      </Card>
+    </Grid.Item>
+    <Grid.Item xs={12} md={4} flex>
+      <Card border>
+        <Card.Header>
+          <h2>Card title</h2>
+        </Card.Header>
+        <Card.Body muted>
+          Nullam aliquam et massa id euismod. Interdum et malesuada fames ac
+          ante ipsum primis in faucibus. Nulla vehicula ornare ligula nec
+          rutrum. Maecenas convallis rutrum metus sed ultricies.
+        </Card.Body>
+      </Card>
+    </Grid.Item>
+  </Grid>
 );


### PR DESCRIPTION
Fixes issue where muted card body did not fill the whole card when in a grid with other taller cards, by adding `display: flex` to the card when it has a muted body.

Before:
![Screenshot 2024-03-14 at 14 36 40](https://github.com/etchteam/mobius/assets/117105692/a2271760-e417-418a-a50e-2d7c798c80bd)

After:
![Screenshot 2024-03-14 at 14 36 28](https://github.com/etchteam/mobius/assets/117105692/662d330a-3ea9-400c-99a4-2228d5365e14)


