### PR TITLE
feat: label as span tag

### DIFF
--- a/src/components/composition/FormGroup/FormGroup.stories.tsx
+++ b/src/components/composition/FormGroup/FormGroup.stories.tsx
@@ -46,7 +46,7 @@ export function Horizontal() {
 
       <FormGroup horizontal>
         <FormGroup.Label>
-          <Label id="my-input-two">
+          <Label id="my-input-two" as="span">
             Input label with a bigger list of form controls
           </Label>
         </FormGroup.Label>

--- a/src/components/controls/Label/Label.tsx
+++ b/src/components/controls/Label/Label.tsx
@@ -7,7 +7,7 @@ interface LabelProps {
   children?: React.ReactNode;
   htmlFor?: string;
   hidden?: boolean;
-  as?: 'label' | 'legend';
+  as?: 'label' | 'legend' | 'span';
   type?: 'secondary';
   [index: string]: any;
 }

--- a/src/components/controls/Radio/Radio.stories.tsx
+++ b/src/components/controls/Radio/Radio.stories.tsx
@@ -25,7 +25,9 @@ export function Checked() {
   return (
     <FormGroup horizontal>
       <FormGroup.Label>
-        <Label id="a-label">Label</Label>
+        <Label id="a-label" as="span">
+          Label
+        </Label>
       </FormGroup.Label>
       <FormGroup.Control>
         <div role="radiogroup" aria-labelledby="a-label">

--- a/src/docs/examples.stories.tsx
+++ b/src/docs/examples.stories.tsx
@@ -70,10 +70,16 @@ export function Form() {
         <FormGroup>
           <Grid wrap>
             <Grid.Item xs={12} md={6}>
-              <Label htmlFor="multiple">Multiple sites</Label>
+              <Label htmlFor="multiple" as="span" id="sites-label">
+                Multiple sites
+              </Label>
             </Grid.Item>
             <Grid.Item xs={12} md={6}>
-              <div role="radiogroup" aria-label="Multiple sites" id="multiple">
+              <div
+                role="radiogroup"
+                aria-labelledby="sites-label"
+                id="multiple"
+              >
                 <Grid>
                   <Grid.Item xs={6}>
                     <Radio name="radio" id="yes">


### PR DESCRIPTION
Add `span` to list of types accepted by `as` prop on `Label` component. This means it can be visually styled the same as other labels, but a `label` tag is not rendered.

Needed to prevent orphaned form labels for things like radio groups (e.g. the following kind of situation)

```
<Label id="radiogroup-label" as="span">
  Radio Group Label
</Label>
<div role="radiogroup" aria-labelledby="radiogroup-label">
  {[1, 2, 3, 4].map((option) => (
    <Radio value={option} name="radio-input">
      Option {option}
    </Radio>
  ))
</div>
```

Related to [WRAP-748](https://linear.app/etch/issue/WRAP-748/minor-form-fixes)