### PR TITLE
feat: HelpText string props

### DIFF
--- a/src/components/content/HelpText/HelpText.stories.tsx
+++ b/src/components/content/HelpText/HelpText.stories.tsx
@@ -27,24 +27,40 @@ export default {
 
 export const Default = () => (
   <FormGroup>
-    <Label htmlFor="my-input">Input label</Label>
-    <Input id="my-input" name="my-input" />
-    <HelpText>Some help text for this input</HelpText>
+    <Label htmlFor="my-input-1">Input label</Label>
+    <Input
+      id="my-input-1"
+      name="my-input-1"
+      aria-describedby="my-input-1-helptext"
+    />
+    <HelpText id="my-input-1-helptext">Some help text for this input</HelpText>
   </FormGroup>
 );
 
 export const Positive = () => (
   <FormGroup>
-    <Label htmlFor="my-input">Input label</Label>
-    <Input id="my-input" name="my-input" />
-    <HelpText type="positive">Yay, it worked!</HelpText>
+    <Label htmlFor="my-input-2">Input label</Label>
+    <Input
+      id="my-input-2"
+      name="my-input-2"
+      aria-describedby="my-input-2-helptext"
+    />
+    <HelpText id="my-input-2-helptext" type="positive">
+      Yay, it worked!
+    </HelpText>
   </FormGroup>
 );
 
 export const Negative = () => (
   <FormGroup>
-    <Label htmlFor="my-input">Input label</Label>
-    <Input id="my-input" name="my-input" />
-    <HelpText type="negative">There was a problem</HelpText>
+    <Label htmlFor="my-input-3">Input label</Label>
+    <Input
+      id="my-input-3"
+      name="my-input-3"
+      aria-describedby="my-input-3-helptext"
+    />
+    <HelpText id="my-input-3-helptext" type="negative">
+      There was a problem
+    </HelpText>
   </FormGroup>
 );

--- a/src/components/content/HelpText/HelpText.tsx
+++ b/src/components/content/HelpText/HelpText.tsx
@@ -6,15 +6,18 @@ import styles from './HelpText.module.scss';
 export default function HelpText({
   children,
   type = 'neutral',
+  ...props
 }: Readonly<{
   children?: React.ReactNode;
   type?: 'neutral' | 'positive' | 'negative';
+  [key: string]: any;
 }>) {
   return (
     <div
       className={classNames(styles['help-text'], {
         [styles[`help-text--${type}`]]: type,
       })}
+      {...props}
     >
       {children}
     </div>


### PR DESCRIPTION
Allow any `string` prop on `HelpText` component so that attributes like `id`, aria attributes etc. can be passed in.

Needed for accessibility e.g. so that an ID can be set on the help text, which the input can then reference using `aria-describedby` to make the text be read out by a screenreader.