### PR TITLE
Fix collapse close animation (and unique ids)

### DIFF
--- a/src/components/controls/Collapse/Collapse.module.scss
+++ b/src/components/controls/Collapse/Collapse.module.scss
@@ -20,9 +20,7 @@
     display: grid;
     grid-template-rows: 0fr;
     transition: grid-template-rows transition.$duration transition.$timing,
-      content-visibility transition.$duration transition.$timing;
-    /* stylelint-disable-next-line property-no-unknown */
-    transition-behavior: allow-discrete;
+      content-visibility transition.$duration transition.$timing allow-discrete;
 
     &--open {
       content-visibility: visible;

--- a/src/components/controls/Collapse/Collapse.stories.tsx
+++ b/src/components/controls/Collapse/Collapse.stories.tsx
@@ -1,7 +1,9 @@
 import { Meta, Story } from '@storybook/react';
-import React from 'react';
+import React, { useState } from 'react';
 
 import Collapse, { CollapseProps } from './Collapse';
+
+import Card from 'components/canvas/Card/Card';
 
 export default {
   title: 'Controls/Collapse',
@@ -40,3 +42,42 @@ export const DefaultOpen: Story = () => (
     </div>
   </Collapse>
 );
+
+DefaultOpen.parameters = {
+  docs: {
+    description: {
+      story:
+        'Set `defaultOpen` to `true` to have the collapse open from initial render.',
+    },
+  },
+};
+
+export const CollapseState: Story = () => {
+  const [open, setOpen] = useState(false);
+
+  const onToggle = function (open?: boolean) {
+    setOpen(open ?? false);
+  };
+
+  return (
+    <Card muted={!open} border={open} shadow={open}>
+      <Card.Body>
+        <Collapse onToggle={onToggle} headerLabel="Click me" align="right">
+          <div>
+            <p>
+              When the collapse is toggled the onToggle event handler is called
+            </p>
+          </div>
+        </Collapse>
+      </Card.Body>
+    </Card>
+  );
+};
+
+CollapseState.parameters = {
+  docs: {
+    description: {
+      story: 'Watch the `onToggle` event to detect the state of the collapse.',
+    },
+  },
+};

--- a/src/components/controls/Collapse/Collapse.tsx
+++ b/src/components/controls/Collapse/Collapse.tsx
@@ -1,6 +1,6 @@
 import cx from 'classnames';
 import uniqueId from 'lodash/uniqueId';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import styles from './Collapse.module.scss';
 
@@ -33,7 +33,7 @@ const Collapse = ({
     onToggle?.(!open);
   };
 
-  const controlId = `collapse-control-${uniqueId()}`;
+  const controlId = useMemo(() => `collapse-control-${uniqueId()}`, []);
   const direction = align === 'right' ? 'row-reverse' : 'row';
 
   return (


### PR DESCRIPTION
**Close animation**

When the Mobius CSS was built as part of a NextJS bundle, allow-discrete is hoisted higher in the definition which causes it to be overwritten by the shorthand transition declaration.

The allow-discrete has been moved into the shorthand transition to stop this happening.

<img width="624" alt="Screenshot 2024-07-23 at 14 35 34" src="https://github.com/user-attachments/assets/c4bd7a00-c261-46a4-a59d-9e6a26e2dce7">

**Unique ids**

These were being regenerated on each render including when the toggle state changed, so the `uniqueId()` call has been moved to a memo to stop it doing that.

**Extras**

Added a story to showcase how the onToggle event can be used.