### PR TITLE
fix: update heading styles

### DIFF
--- a/src/components/content/Text/Text.stories.tsx
+++ b/src/components/content/Text/Text.stories.tsx
@@ -20,11 +20,26 @@ export default {
   },
 } as Meta;
 
+export const TextStory = (args: TextProps) => (
+  <Text {...args}>The future is in our hands to shape.</Text>
+);
+
+TextStory.args = {
+  as: 'span',
+  size: 'base',
+};
+
+TextStory.storyName = 'Text';
+
 export const Sizes = () => {
   const sizes: TextProps['size'][] = [
+    'base',
     'h1',
     'h2',
     'h3',
+    'h4',
+    'h5',
+    'h6',
     'xl',
     'lg',
     'md',

--- a/src/components/content/Text/Text.tsx
+++ b/src/components/content/Text/Text.tsx
@@ -18,7 +18,8 @@ export interface TextProps {
     | 'h2'
     | 'h3'
     | 'h4'
-    | 'h5';
+    | 'h5'
+    | 'h6';
   readonly align?: 'left' | 'center' | 'right';
   readonly display?: 'inline-block' | 'inline' | 'block';
   readonly weight?: Weights;

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -14,8 +14,16 @@ body {
 h1,
 h2,
 h3,
-h4 {
+h4,
+h5,
+h6 {
   @include title.title;
+}
+
+h1,
+h2,
+h3,
+h4 {
   font-family: var(--font-family-heading);
   text-transform: uppercase;
 }

--- a/src/styles/mixins/title.scss
+++ b/src/styles/mixins/title.scss
@@ -1,7 +1,6 @@
 @mixin title {
   color: var(--skin-heading-color);
-  font-weight: var(--heading-font-weight, 700);
-  letter-spacing: -0.025em;
+  font-weight: var(--heading-font-weight, var(--font-weight-bold));
   line-height: var(--font-line-height-sm);
   margin-bottom: var(--spacing-xs);
   margin-top: 0;

--- a/src/types/font.type.ts
+++ b/src/types/font.type.ts
@@ -8,6 +8,8 @@ export type Sizes =
   | 'h1'
   | 'h2'
   | 'h3'
-  | 'h4';
+  | 'h4'
+  | 'h5'
+  | 'h6';
 
 export type Weights = 'base' | 'light' | 'bold' | 'black';


### PR DESCRIPTION
Adjust the heading styles
- Remove negative letter spacing that had been used for the old font
- Change fallback font weight to variable
- Use heading styles (except font) on `h5` and `h6`

Also adds missing `h5` and `h6` types and updates the `Text` component story