### PR TITLE
fix: faq click a11y

### DIFF
--- a/src/components/content/Faq/Faq.module.scss
+++ b/src/components/content/Faq/Faq.module.scss
@@ -1,9 +1,28 @@
 .faq {
-  --card-border-radius: var(--radius-sm);
-
+  background: var(--skin-background-muted);
+  border: 1px solid var(--skin-border-color-muted);
+  border-radius: var(--radius-sm);
+  transition:
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   width: 100%;
+
+  &--open {
+    background: var(--skin-background);
+    border-color: var(--skin-border-color);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  }
 
   &__content {
     padding-top: var(--spacing-md);
+  }
+
+  &:hover {
+    border-color: var(--input-border-hover);
+  }
+
+  &:focus-within {
+    border-color: var(--input-border-focus);
   }
 }

--- a/src/components/content/Faq/Faq.tsx
+++ b/src/components/content/Faq/Faq.tsx
@@ -3,7 +3,6 @@ import React, { useState } from 'react';
 
 import styles from './Faq.module.scss';
 
-import Card from 'components/canvas/Card/Card';
 import Title from 'components/content/Title/Title';
 import Collapse from 'components/controls/Collapse/Collapse';
 
@@ -22,30 +21,25 @@ const Faq = ({ question, children }: FaqProps) => {
       itemProp="mainEntity"
       itemType="https://schema.org/Question"
     >
-      {/* Use an empty onClick function to activate clickable card styles */}
-      <Card muted={!open} border shadow={open} onClick={() => {}}>
-        <Card.Body padded={false}>
-          <Collapse
-            textDecoration="none"
-            onToggle={setOpen}
-            headerLabel={
-              <Title as="h3" size="h4" family="default">
-                <span itemProp="name">{question}</span>
-              </Title>
-            }
-            align="right"
-          >
-            <div
-              className={styles.faq__content}
-              itemScope
-              itemProp="acceptedAnswer"
-              itemType="https://schema.org/Answer"
-            >
-              {children}
-            </div>
-          </Collapse>
-        </Card.Body>
-      </Card>
+      <Collapse
+        textDecoration="none"
+        onToggle={setOpen}
+        headerLabel={
+          <Title as="h3" size="h4" family="default">
+            <span itemProp="name">{question}</span>
+          </Title>
+        }
+        align="right"
+      >
+        <div
+          className={styles.faq__content}
+          itemScope
+          itemProp="acceptedAnswer"
+          itemType="https://schema.org/Answer"
+        >
+          {children}
+        </div>
+      </Collapse>
     </div>
   );
 };


### PR DESCRIPTION
Onclick handler on card inside FAQ component was causing a11y tests to fail because of nested interactive elements.
The empty handler was being used to make the card 'clickable' to gain hover and focus styles on the FAQ.

Couldn't find another way to keep those styles on the card but pass a11y tests, so had to remove the card and set the styles on the FAQ component manually.