### PR TITLE
feat: card additional props

### DIFF
--- a/src/components/canvas/Card/Card.tsx
+++ b/src/components/canvas/Card/Card.tsx
@@ -44,6 +44,7 @@ class Card extends Component<CardProps> {
       muted,
       onClick,
       shadow,
+      ...props
     } = this.props;
 
     const CardElement = as ?? (href ? 'a' : 'div');
@@ -70,6 +71,7 @@ class Card extends Component<CardProps> {
         onKeyDown={handleKeyDown}
         role={onClick ? 'button' : undefined}
         id={id}
+        {...props}
       >
         {arrow && (
           <div className={styles.card__arrow}>


### PR DESCRIPTION
Pass additional props on Card through (they were already allowed, they just weren't being used).
Needed to be able to set `aria-label` on Cards as links and buttons, for example.