### PR TITLE
fix: install mobius tokens from right place

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3193,7 +3193,7 @@
     },
     "node_modules/@etchteam/mobius-tokens": {
       "version": "1.4.0",
-      "resolved": "https://policies-io-371393245021.d.codeartifact.eu-west-1.amazonaws.com/npm/petshop/@etchteam/mobius-tokens/-/mobius-tokens-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/@etchteam/mobius-tokens/-/mobius-tokens-1.4.0.tgz",
       "integrity": "sha512-1hFrkAdOvaX+2hW4ytKPPx1Swt+cTC3ivxIMiCjNlpJhP81XqfEFr5UgK8/QQhW3F3suf09G5oYG4m3Erz93RA==",
       "license": "MIT"
     },
@@ -30586,7 +30586,7 @@
     },
     "@etchteam/mobius-tokens": {
       "version": "1.4.0",
-      "resolved": "https://policies-io-371393245021.d.codeartifact.eu-west-1.amazonaws.com/npm/petshop/@etchteam/mobius-tokens/-/mobius-tokens-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/@etchteam/mobius-tokens/-/mobius-tokens-1.4.0.tgz",
       "integrity": "sha512-1hFrkAdOvaX+2hW4ytKPPx1Swt+cTC3ivxIMiCjNlpJhP81XqfEFr5UgK8/QQhW3F3suf09G5oYG4m3Erz93RA=="
     },
     "@etchteam/storybook-addon-css-variables-theme": {


### PR DESCRIPTION
Installs mobius tokens from the right npm registry.