### PR TITLE
feat: add stream colors to ContainerSvg

### DIFF
--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -23,7 +23,13 @@ export type Colour =
   | 'maroon'
   | 'purple'
   | 'duckEgg'
-  | 'transparent';
+  | 'transparent'
+  | 'no-stream'
+  | 'dry-stream'
+  | 'residual-stream'
+  | 'food-stream'
+  | 'garden-stream'
+  | 'organic-stream';
 
 export type Name =
   | 'Box'

--- a/src/styles/variables/container.scss
+++ b/src/styles/variables/container.scss
@@ -22,4 +22,10 @@ $colors: (
   'purple': var(--mobius-container-color-purple),
   'duckEgg': var(--mobius-container-color-duck-egg),
   'transparent': var(--mobius-container-color-transparent),
+  'no-stream': var(--mobius-color-no-stream),
+  'dry-stream': var(--mobius-color-dry-stream),
+  'residual-stream': var(--mobius-color-residual-stream),
+  'food-stream': var(--mobius-color-food-stream),
+  'garden-stream': var(--mobius-color-garden-stream),
+  'organic-stream': var(--mobius-color-organic-stream),
 );


### PR DESCRIPTION
Adds stream colours to ContainerSvg colour options.

![image](https://github.com/user-attachments/assets/f9acc1ad-a05d-4f45-b503-5116745a24cb)
