### PR TITLE
Transparent menubar

### DIFF
--- a/src/components/controls/Menubar/Menubar.module.scss
+++ b/src/components/controls/Menubar/Menubar.module.scss
@@ -1,7 +1,13 @@
 @use '../../../styles/variables/breakpoint';
 
 .menubar {
-  background: var(--skin-background);
+  --tab-background: var(--skin-background);
+  --tab-background-active: var(--input-background-disabled);
+  --tab-color-active: var(--color-body);
+  --tab-highlight-color: var(--skin-color);
+  --tab-highlight-width: 4px;
+
+  background: var(--tab-background);
 
   @media (min-width: breakpoint.$tablet) {
     align-items: center;
@@ -31,10 +37,6 @@
   }
 
   &__tab {
-    --tab-background: var(--skin-background);
-    --tab-highlight-color: var(--skin-color);
-    --tab-highlight-width: 4px;
-
     display: block;
     font-size: var(--font-size-sm);
     font-weight: var(--font-weight-bold);
@@ -83,11 +85,11 @@
         opacity: 1;
       }
 
-      background: var(--input-background-disabled);
-      color: var(--color-body);
+      background: var(--tab-background-active);
+      color: var(--tab-color-active);
 
       a {
-        color: var(--color-body);
+        color: var(--tab-color-active);
       }
     }
 
@@ -115,5 +117,11 @@
       padding: var(--spacing-md);
       text-decoration: none;
     }
+  }
+
+  &--transparent {
+    --tab-background: transparent;
+    --tab-background-active: var(--skin-background);
+    --tab-color-active: car(--skin-color);
   }
 }

--- a/src/components/controls/Menubar/Menubar.module.scss
+++ b/src/components/controls/Menubar/Menubar.module.scss
@@ -42,7 +42,7 @@
     position: relative;
 
     a {
-      color: var(--skin-background-muted-dark);
+      color: color-mix(in srgb, var(--skin-color) 75%, transparent 25%);
       text-decoration: none;
       transition: background var(--transition) color var(--transition);
 
@@ -71,7 +71,6 @@
       }
 
       align-items: center;
-      color: var(--skin-background-muted-dark);
       display: flex;
       justify-content: center;
       min-height: var(--spacing-thumb);

--- a/src/components/controls/Menubar/Menubar.stories.tsx
+++ b/src/components/controls/Menubar/Menubar.stories.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import Menubar from './Menubar';
 
+import Skin, { skins, emphasisSkins } from 'components/composition/Skin/Skin';
 import Icon from 'components/content/Icon/Icon';
 
 export default {
@@ -27,26 +28,38 @@ export default {
       },
     },
   },
+  argTypes: {
+    skin: {
+      control: 'select',
+      options: [...skins, ...emphasisSkins],
+    },
+  },
 } as Meta;
 
 export const FourTabs: StoryFn = (args) => (
-  <Menubar {...args}>
-    <Menubar.Tabs>
-      <Menubar.Tab completed>
-        <a href="#">Service</a>
-      </Menubar.Tab>
-      <Menubar.Tab active>
-        <a href="#">Economic</a>
-      </Menubar.Tab>
-      <Menubar.Tab>
-        <a href="#">Environmental</a>
-      </Menubar.Tab>
-      <Menubar.Tab disabled>
-        <span>Technical</span>
-      </Menubar.Tab>
-    </Menubar.Tabs>
-  </Menubar>
+  <Skin skin={args.skin}>
+    <Menubar {...args}>
+      <Menubar.Tabs>
+        <Menubar.Tab completed>
+          <a href="#">Service</a>
+        </Menubar.Tab>
+        <Menubar.Tab active>
+          <a href="#">Economic</a>
+        </Menubar.Tab>
+        <Menubar.Tab>
+          <a href="#">Environmental</a>
+        </Menubar.Tab>
+        <Menubar.Tab disabled>
+          <span>Technical</span>
+        </Menubar.Tab>
+      </Menubar.Tabs>
+    </Menubar>
+  </Skin>
 );
+
+FourTabs.args = {
+  skin: 'light',
+};
 
 export const TwoTabs: StoryFn = () => (
   <Menubar>

--- a/src/components/controls/Menubar/Menubar.stories.tsx
+++ b/src/components/controls/Menubar/Menubar.stories.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import Menubar from './Menubar';
 
+import Card from 'components/canvas/Card/Card';
 import Skin, { skins, emphasisSkins } from 'components/composition/Skin/Skin';
 import Icon from 'components/content/Icon/Icon';
 
@@ -90,4 +91,29 @@ export const WithBackButton = () => (
       </Menubar.Tab>
     </Menubar.Tabs>
   </Menubar>
+);
+
+export const Transparent: StoryFn = () => (
+  <Skin skin="light">
+    <Card muted>
+      <Card.Body>
+        <Menubar transparent>
+          <Menubar.Tabs>
+            <Menubar.Tab completed>
+              <a href="#">Waste</a>
+            </Menubar.Tab>
+            <Menubar.Tab active>
+              <a href="#">Containers</a>
+            </Menubar.Tab>
+            <Menubar.Tab>
+              <a href="#">Cost</a>
+            </Menubar.Tab>
+            <Menubar.Tab disabled>
+              <span>Results</span>
+            </Menubar.Tab>
+          </Menubar.Tabs>
+        </Menubar>
+      </Card.Body>
+    </Card>
+  </Skin>
 );

--- a/src/components/controls/Menubar/Menubar.tsx
+++ b/src/components/controls/Menubar/Menubar.tsx
@@ -39,8 +39,20 @@ const MenubarBack = ({ children }: { readonly children?: React.ReactNode }) => (
   </div>
 );
 
-const Menubar = ({ children }: { readonly children?: React.ReactNode }) => (
-  <nav className={styles.menubar}>{children}</nav>
+const Menubar = ({
+  children,
+  transparent,
+}: {
+  readonly children?: React.ReactNode;
+  readonly transparent?: boolean;
+}) => (
+  <nav
+    className={classNames(styles.menubar, {
+      [styles['menubar--transparent']]: transparent,
+    })}
+  >
+    {children}
+  </nav>
 );
 
 Menubar.Back = MenubarBack;

--- a/src/styles/base/_skins.scss
+++ b/src/styles/base/_skins.scss
@@ -1,6 +1,10 @@
-:root {
-  $skins: light, dark, info, attention, positive, negative, neutral;
+@use '../mixins/skin';
 
+$skins: light, dark, info, attention, neutral, positive, negative;
+
+@include skin.create-skins($skins);
+
+:root {
   @each $skin in $skins {
     --skin-background-#{$skin}: var(--mobius-skin-background-#{$skin});
     --skin-background-muted-#{$skin}: var(

--- a/src/styles/themes/default/main.scss
+++ b/src/styles/themes/default/main.scss
@@ -1,5 +1,0 @@
-@use '../../mixins/skin';
-
-$skins: light, dark, info, attention, neutral, positive, negative;
-
-@include skin.create-skins($skins);


### PR DESCRIPTION
Transparent menubar variant for BoR rebranded calculator nav.
Also fixes broken skins.
<img width="847" alt="Screenshot 2025-01-29 at 10 43 43" src="https://github.com/user-attachments/assets/786c98b1-0653-420f-abbd-55ad19dfb07f" />
