### PR TITLE
Menubar mobile and a11y

### DIFF
--- a/src/components/controls/Menubar/Menubar.module.scss
+++ b/src/components/controls/Menubar/Menubar.module.scss
@@ -28,6 +28,7 @@
 
   &__tabs {
     display: flex;
+    justify-content: center;
     margin: 0;
     padding: 0;
 

--- a/src/components/controls/Menubar/Menubar.tsx
+++ b/src/components/controls/Menubar/Menubar.tsx
@@ -42,14 +42,17 @@ const MenubarBack = ({ children }: { readonly children?: React.ReactNode }) => (
 const Menubar = ({
   children,
   transparent,
+  ...props
 }: {
   readonly children?: React.ReactNode;
   readonly transparent?: boolean;
+  [key: string]: unknown;
 }) => (
   <nav
     className={classNames(styles.menubar, {
       [styles['menubar--transparent']]: transparent,
     })}
+    {...props}
   >
     {children}
   </nav>


### PR DESCRIPTION
Minor changes to the Menubar to fix the mobile layout (tabs weren't centred on small screens) and a11y (allow additional props so that aria label can be set).